### PR TITLE
use sqlite for dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,11 @@ db.sqlite3
 *.pyc
 bin/environment.sh
 /staticfiles/
+*/staticfiles/
 package-lock.json
 client-secret.json
 api_key.py
 credentials.tar.gz
+.idea/
+.venv/
+.virtualenv/

--- a/backend/settings/core.py
+++ b/backend/settings/core.py
@@ -22,13 +22,6 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
 
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = bool(os.environ.get('DEBUG', False))
-
-
-ALLOWED_HOSTS = ["*"]
-
-
 # Application definition
 
 INSTALLED_APPS = [
@@ -73,27 +66,6 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = 'backend.wsgi.application'
-
-
-# Database
-# https://docs.djangoproject.com/en/1.11/ref/settings/#databases
-
-DATABASES = {
-    # 'default': {
-    #     'ENGINE': 'django.db.backends.sqlite3',
-    #     'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-    # }
-
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'PASSWORD': os.environ.get('POSTGRES_PASSWORD'),
-        'NAME': os.environ.get('POSTGRES_NAME'),
-        'USER': os.environ.get('POSTGRES_USER'),
-        'HOST': os.environ.get('POSTGRES_HOST'),
-        'PORT': os.environ.get('POSTGRES_PORT')
-    }
-}
-
 
 # Password validation
 # https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators

--- a/backend/settings/dev.py
+++ b/backend/settings/dev.py
@@ -1,0 +1,12 @@
+from .core import *
+
+DEBUG = bool(os.environ.get('DEBUG', False))
+ALLOWED_HOSTS = ["*"]
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'db.sqlite3'
+    }
+}
+

--- a/backend/settings/production.py
+++ b/backend/settings/production.py
@@ -1,0 +1,21 @@
+from .core import *
+
+DEBUG = False
+ALLOWED_HOSTS = ["localhost", "wobbly.app"]
+
+DATABASES = {
+    # 'default': {
+    #     'ENGINE': 'django.db.backends.sqlite3',
+    #     'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    # }
+
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'PASSWORD': os.environ.get('POSTGRES_PASSWORD'),
+        'NAME': os.environ.get('POSTGRES_NAME'),
+        'USER': os.environ.get('POSTGRES_USER'),
+        'HOST': os.environ.get('POSTGRES_HOST'),
+        'PORT': os.environ.get('POSTGRES_PORT')
+    }
+}
+

--- a/bin/docker-entrypoint-development.sh
+++ b/bin/docker-entrypoint-development.sh
@@ -1,21 +1,5 @@
-#! /bin/bash
-
-SLEEP_SECONDS=3
-
->&2 echo "Checking Postgres status..."
-
-# https://docs.docker.com/compose/startup-order/
-export PGPASSWORD=$POSTGRES_PASSWORD
-until psql -h "$POSTGRES_HOST" -U "$POSTGRES_USER" -p "$POSTGRES_PORT" -d postgres -c '\q'
-do
-  >&2 echo "Postgres is unavailable - sleeping"
-  sleep $SLEEP_SECONDS
-done
->&2 echo "Postgres is up"
+#!/bin/bash
 
 python manage.py collectstatic --noinput
-
-python manage.py makemigrations --noinput
 python manage.py migrate --noinput
-
 gunicorn backend.wsgi -c gunicorn_config.py

--- a/docker-compose-development.yml
+++ b/docker-compose-development.yml
@@ -14,14 +14,4 @@ services:
     environment:
       - DJANGO_SECRET_KEY
       - DEBUG=True
-      - POSTGRES_USER=postgres
-      - POSTGRES_NAME=postgres
-      - POSTGRES_HOST=wobbly-backend-db
-      - POSTGRES_PORT=5432    
-    depends_on:
-      - wobbly-backend-db   
-
-  wobbly-backend-db:
-    image: postgres
-    ports:
-      - "5432:5432"
+      - DJANGO_SETTINGS_MODULE=backend.settings.dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,3 +20,4 @@ services:
       - POSTGRES_PORT
       - POSTGRES_PASSWORD
       - DJANGO_SECRET_KEY
+      - DJANGO_SETTINGS_MODULE=backend.settings.production


### PR DESCRIPTION
* removes the dependency on the postgres container for dev'ing
* makes it easy to run `manage.py` commands, as long as you add the flag `--settings=backend.settings.dev`